### PR TITLE
. ApproxCount returns ~number of items in BloomFilter.

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -140,6 +140,19 @@ func (f *BloomFilter) K() uint {
 	return f.k
 }
 
+// B returns the values for the bitSet used the by Bloom Filter
+func (f *BloomFilter) B() bitset.BitSet {
+	return *f.b
+}
+
+// ApproxCount computes the approximate number of items in the Bloom Filter
+func (f *BloomFilter) ApproxCount() uint {
+	m := float64(f.m)
+	ratio := m / float64(f.k)
+	ln := math.Log(1 - float64(f.b.Count())/m)
+	return uint(-1 * int(ratio*ln))
+}
+
 // Add data to the Bloom Filter. Returns the filter (allows chaining)
 func (f *BloomFilter) Add(data []byte) *BloomFilter {
 	h := baseHashes(data)

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"math"
+	"strconv"
 	"testing"
 )
 
@@ -267,6 +268,27 @@ func TestK(t *testing.T) {
 	}
 }
 
+func TestCount(t *testing.T) {
+	f := New(1000, 4)
+	f.Add([]byte("this"))
+	f.Add([]byte("that"))
+	if f.ApproxCount() != 2 {
+		t.Errorf("approximate count not accurate: %d", f.ApproxCount())
+	}
+	f.Add([]byte("the other"))
+	f.Add([]byte("another"))
+	f.Add([]byte("that"))
+	if f.ApproxCount() != 4 {
+		t.Errorf("approximate count not accurate: %d", f.ApproxCount())
+	}
+	for i := 0; i < 900; i++ {
+		f.Add([]byte(strconv.Itoa(i)))
+	}
+	if f.ApproxCount() < 900 || f.ApproxCount() > 940 {
+		t.Errorf("approximate count not accurate: %d", f.ApproxCount())
+	}
+}
+
 func TestMarshalUnmarshalJSON(t *testing.T) {
 	f := New(1000, 4)
 	data, err := json.Marshal(f)
@@ -452,6 +474,15 @@ func BenchmarkCombinedTestAndAdd(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		binary.BigEndian.PutUint32(key, uint32(i))
 		f.TestAndAdd(key)
+	}
+}
+
+func BenchmarkApproxCount(b *testing.B) {
+	f := New(100000, 35)
+	for i := 0; i < 10000; i++ {
+		f.AddString(strconv.Itoa(i))
+		b.ResetTimer()
+		f.ApproxCount()
 	}
 }
 


### PR DESCRIPTION
B() makes bitset values publicly readable